### PR TITLE
report errors unrelated to expectations even in case some expectations passed 

### DIFF
--- a/main.go
+++ b/main.go
@@ -291,7 +291,7 @@ func call(suitePath string, call Call, vars *Vars) *CallTrace {
 		checkErr := exp.check(&testResp)
 
 		if checkErr != nil {
-			trace.addError(checkErr)
+			trace.addFail(checkErr)
 			return trace
 		}
 

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -57,3 +57,13 @@ func (mw *MockWriter) Write(p []byte) (n int, err error) {
 func (mw *MockWriter) passed() bool {
 	return strings.Contains(mw.actualWriting, mw.expectedWriting)
 }
+
+func TestJUnitReporterEmptyResults(t *testing.T) {
+	// given
+
+	// when
+	NewJUnitReporter("").Report([]TestResult{})
+
+	// then
+	// no nil pointer panic
+}

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -1,15 +1,59 @@
 package main
 
 import (
+	"errors"
+	"github.com/fatih/color"
+	"strings"
+	"sync"
 	"testing"
 )
 
-func TestJUnitReporterEmptyResults(t *testing.T) {
+func TestConsoleReporterReport_ErrorAfterPassedExp_Reported(t *testing.T) {
 	// given
+	reportedError := "test err"
+	results := []TestResult{
+		{
+			Traces: []*CallTrace{
+				{
+					ExpDesc:    map[string]bool{"Status code is 200": false},
+					ErrorCause: errors.New(reportedError),
+				},
+			},
+		}, // error without expectation description
+	}
+
+	writer := MockWriter{
+		expectedWriting: reportedError,
+	}
+
+	reporter := &ConsoleReporter{ExitCode: 0, Writer: &writer, ioMutex: &sync.Mutex{}, LogHTTP: false}
+
+	color.Output = &writer // prevent stdout and invalid test result parsing in IDE (reacts on words 'FAILED')
 
 	// when
-	NewJUnitReporter("").Report([]TestResult{})
+	reporter.Report(results)
 
 	// then
-	// no nil pointer panic
+	if !writer.passed() {
+		t.Errorf("Expected writing %s was not met in %s", writer.expectedWriting, writer.actualWriting)
+	}
+}
+
+type MockWriter struct {
+	expectedWriting string
+	actualWriting   string
+}
+
+func (mw *MockWriter) Write(p []byte) (n int, err error) {
+
+	in := string(p)
+	mw.actualWriting += in
+
+	//os.Stdout.Write(p)
+
+	return len(p), nil
+}
+
+func (mw *MockWriter) passed() bool {
+	return strings.Contains(mw.actualWriting, mw.expectedWriting)
 }

--- a/types.go
+++ b/types.go
@@ -328,7 +328,7 @@ func (trace *CallTrace) addExp(desc string) {
 	trace.ExpDesc[desc] = false
 }
 
-func (trace *CallTrace) addError(err error) {
+func (trace *CallTrace) addFail(err error) {
 	if trace.ExpDesc == nil {
 		trace.ExpDesc = make(map[string]bool)
 	}
@@ -342,9 +342,19 @@ func (trace *CallTrace) hasError() bool {
 }
 
 // Terminated returns true if request failed due to the issues with making request
-// or parsing response, not due to unmet expectations
+// or parsing response, not due to failed expectations
 func (trace *CallTrace) Terminated() bool {
-	return trace.ErrorCause != nil && len(trace.ExpDesc) == 0
+	return trace.hasError() && !trace.hasFailedExp()
+}
+
+func (trace *CallTrace) hasFailedExp() bool {
+	for _, failed := range trace.ExpDesc {
+		if failed {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Response wraps test call HTTP response


### PR DESCRIPTION
- more clear distinction between error and expectation failure
- trace.Terminated() now only considers failed expectations, not all
should fix #88 