### PR TITLE
adding --info-curl

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"moul.io/http2curl"
 )
 
 const (
@@ -32,6 +33,7 @@ func init() {
 		h += "      --throttle	Execute no more than specified number of requests per second (in suite)\n"
 		h += "  -h, --help		Print usage\n"
 		h += "  -i, --info		Enable info mode. Print request and response details\n"
+		h += "      --info-curl Enable info mode. Print request and response details. Request is printed as curl command\n"
 		h += "      --junit		Enable junit xml reporter\n"
 		h += "      --junit-output	Destination for junit report files\n"
 		h += "  -v, --version		Print version information and quit\n\n"
@@ -51,6 +53,7 @@ var (
 	workersFlag     int
 	throttleFlag    int
 	infoFlag        bool
+	infoCurlFlag    bool
 	debugFlag       bool
 	helpFlag        bool
 	versionFlag     bool
@@ -81,6 +84,7 @@ func main() {
 
 	flag.BoolVar(&infoFlag, "i", false, "Enable info mode. Print request and response details.")
 	flag.BoolVar(&infoFlag, "info", false, "Enable info mode. Print request and response details.")
+	flag.BoolVar(&infoCurlFlag, "info-curl", false, "Enable info mode. Print request and response details. Request is printed as curl command")
 
 	flag.StringVar(&hostFlag, "H", "", "Test server address. Example: http://example.com/api.")
 	flag.IntVar(&workersFlag, "w", 1, "Execute test sutes in parallel with provided numer of workers. Default is 1.")
@@ -216,7 +220,7 @@ func runSuite(suite TestSuite) []TestResult {
 }
 
 func createReporter() Reporter {
-	reporters := []Reporter{NewConsoleReporter(infoFlag)}
+	reporters := []Reporter{NewConsoleReporter(infoFlag||infoCurlFlag)}
 	if junitFlag {
 		path, _ := filepath.Abs(junitOutputFlag)
 		reporters = append(reporters, NewJUnitReporter(path))
@@ -254,7 +258,7 @@ func call(suitePath string, call Call, vars *Vars) *CallTrace {
 		return trace
 	}
 
-	trace.RequestDump = dumpRequest(req, bodyToSend)
+	trace.RequestDump = dumpRequest(req, bodyToSend, infoCurlFlag)
 	trace.RequestMethod = req.Method
 	trace.RequestURL = req.URL.String()
 
@@ -462,7 +466,11 @@ func rememberHeaders(header http.Header, remember map[string]string, vars *Vars)
 	}
 }
 
-func dumpRequest(req *http.Request, body string) string {
+func dumpRequest(req *http.Request, body string, dumpAsCurl bool) string {
+	if dumpAsCurl {
+		command, _ := http2curl.GetCurlCommand(req)
+		return command.String()
+	}
 	buf := bytes.NewBufferString("")
 
 	buf.WriteString(fmt.Sprintf("%s %s %s\n", req.Method, req.URL.String(), req.Proto))


### PR DESCRIPTION
dumping request as `curl` command.
it makes it easier to check when one step in the test fails. in my case, i copy the generated curl command with resolved variables (e.g. authorization token) at the failed step and review it on its own (using [insomnia](https://insomnia.rest) for example, where you can use the generated `curl` command directly).
it also makes it easier to 'share' the generated requests for further usage (e.g. documentation)