### PR TITLE
Dry run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Options:
   -h, --help      Print usage
   -i, --info      Enable info mode. Print request and response details.
   -d, --debug     Enable debug mode
+      --dry-run   Enable dry run mode when no HTTP calls are performed
       --junit     Enable junit xml reporter
   -v, --version   Print version information and quit
 
@@ -441,6 +442,10 @@ List of context variables
 }
 ```
 
+
+## Dry run mode
+
+Dry run mode runs test suite but does not execute calls. This could be used in CI/CD pipelines to quickly validate test suite changes. For example, a missed bracket or duplicated test name will be spot in dry run.
 
 ## Editor integration
 

--- a/main.go
+++ b/main.go
@@ -304,10 +304,6 @@ func call(requestConfig *RequestConfig, rewriteConfig *RewriteConfig, suitePath 
 		return trace
 	}
 
-	if dryRunFlag {
-		return trace
-	}
-
 	req, err := populateRequest(requestConfig, on, bodyToSend, tmplCtx)
 	if err != nil {
 		trace.ErrorCause = err
@@ -317,6 +313,10 @@ func call(requestConfig *RequestConfig, rewriteConfig *RewriteConfig, suitePath 
 	trace.RequestDump = dumpRequest(req, bodyToSend, infoCurlFlag)
 	trace.RequestMethod = req.Method
 	trace.RequestURL = req.URL.String()
+
+	if dryRunFlag {
+		return trace
+	}
 
 	client := &http.Client{}
 


### PR DESCRIPTION
Implements GH-104

Dry run mode includes tests suites parsing, request context and body sanity check but no actual request population nor sending, and obviously no response parsing.

Example of suites validation:
![image](https://user-images.githubusercontent.com/13200447/160571108-98d7dbda-e8b0-4841-b94b-746f1d69a856.png)

Example of fail:
![image](https://user-images.githubusercontent.com/13200447/160570893-bb9ebeef-bc88-476a-b071-43c7b32936fb.png)

This validation will not prevent from some other misuses. For example, incorrect response parsing etc. However, this would be a concrete test problem when we are trying to prevent a situation when a test fails the whole run.